### PR TITLE
Fix save and cleanup workspace

### DIFF
--- a/src/GraphiQLWorkspace.jsx
+++ b/src/GraphiQLWorkspace.jsx
@@ -29,6 +29,8 @@ export class GraphiQLWorkspace extends React.Component {
       visited: [props.config.getActiveId()]
     }
 
+    this.bootstrapOptions = props.config.getBootstrapOptions();
+
     var orig = document.addEventListener
     document.addEventListener = function (name, fn) {
       // please don't look here... it's terrible and very very fragile
@@ -137,7 +139,7 @@ export class GraphiQLWorkspace extends React.Component {
       })
     } else if (action == "clean") {
       this.state.config.cleanup()
-      const newConfig = new AppConfig("graphiql", graphiql.bootstrapOptions)
+      const newConfig = new AppConfig("graphiql", this.bootstrapOptions)
 
       this.setState({
         config: newConfig,

--- a/src/config.js
+++ b/src/config.js
@@ -67,6 +67,10 @@ export class State {
     else
       return undefined
   }
+
+  removeItem(key) {
+    localStorage.removeItem(this.prefix() + key)
+  }
 }
 
 function sameQuery(q1, q2) {

--- a/src/config.js
+++ b/src/config.js
@@ -87,6 +87,8 @@ export class AppConfig {
         defaultHeaders = []
       } = options
 
+      this.bootstrapOptions = options;
+
       this.state = new State(key, {
         key: key,
         lastId: 0,
@@ -118,6 +120,10 @@ export class AppConfig {
 
       this.tabInfo = tabs.map(t => new TabConfig(t))
     }
+  }
+
+  getBootstrapOptions() {
+    return this.bootstrapOptions;
   }
 
   getSavedQueries() {


### PR DESCRIPTION
Save workspace got broken with latest GraphiQL which now leverages localStorage.removeItem so we have to provide this method as well.

Not exactly sure how we broken cleanup workspace but in any case, we dont depend on global variable anymore to restore the initial workspace with the bootstrapped options.