### PR TITLE
Fix 'graphiql-subscriptions-fetcher' import

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "react": "global:React",
     "react-dom": "global:ReactDOM"
   },
-  "browser": {
-    "graphiql-subscriptions-fetcher": "./node_modules/graphiql-subscriptions-fetcher/dist/fetcher.js"
-  },
   "scripts": {
     "build": "./scripts/build.sh",
     "quickBuild": "./scripts/quickBuild.sh",

--- a/src/GraphiQLTab.jsx
+++ b/src/GraphiQLTab.jsx
@@ -24,7 +24,7 @@ import {introspectionQuery} from './utility/introspectionQueries';
 
 import {buildClientSchema} from 'graphql';
 
-import {graphQLFetcher} from 'graphiql-subscriptions-fetcher';
+import {graphQLFetcher} from 'graphiql-subscriptions-fetcher/dist/fetcher';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
 
 import _ from 'lodash'


### PR DESCRIPTION
Closes #24
Reason: https://github.com/apollographql/GraphiQL-Subscriptions-Fetcher/issues/4

cc @tlvenn